### PR TITLE
Fixed dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ RUN npm ci
 
 # Copy the rest of the files into the container and build
 COPY . .
-RUN npm run build –prod
+RUN npm run build --prod
 
 FROM nginx:alpine
 COPY –from=build /source/dist/lotospainbackoffice /usr/share/nginx/html


### PR DESCRIPTION
Se ha intercambiado el guion largo por dos normales.
La terminal no reconoce el anterior guion y detiene la puesta en compilación. La siguiente imagen muestra los logs en el momento en el que el script dockerfile falla:
![image](https://github.com/AlexVare/LotoSpainBackOffice/assets/165786947/e0327d00-3d5d-431c-a6ec-eb15b07ee461)
![image](https://github.com/AlexVare/LotoSpainBackOffice/assets/165786947/6f13fdab-cb2a-4897-8aef-98bd4aef279c)


La documentación indica que se deben usar dos guiones, aunque en pruebas locales también funciona con uno solo. Referencia: [Angular CLI build](https://docs.angular.lat/cli/build)
